### PR TITLE
Add more info about the conference team to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,19 @@
-# conferences
-Focusing on R Foundation conferences, liaising with organizers/program committee on policies and inclusion initiatives.
+# Conferences
 
-Ongoing projects:
+This repository belongs to the conference team. This team focus on R Foundation conferences, liaising with organizers/program committee on policies and inclusion initiatives. You can learn more about the team in these document: https://github.com/forwards/conferences/blob/master/Introduction%20to%20the%20Forwards%20Conferences%20Team.md
+
+## Ongoing projects:
 - [Documentation](https://github.com/forwards/conferences/blob/master/Documentation_plans.md) to better intorduce the team's previous projects to new conference organisers.
+- [Events Best Practices](https://github.com/forwards/event_best_practices/blob/master/README.md)
+- [useR! Knowledge base](https://rconf.gitlab.io/userknowledgebase/). (Repo: https://gitlab.com/rconf/userknowledgebase)
+- [useR! Info Board](https://rconf.gitlab.io/userinfoboard/). (Repo: https://gitlab.com/rconf/userinfoboard)
+
+You can also take a look at our project board and task issues:
+- https://github.com/orgs/forwards/projects/5
+- https://github.com/forwards/tasks/issues?q=is%3Aissue+is%3Aopen+label%3Aconferences-team
+
+
+## Finished projects:
 - [Forwards session for useR!2020 European Hub](https://user2020muc.r-project.org/)
 - Liasing with useR!2020 St. Louis 
 - Liasing with UseR!2020 Eurpopean hub


### PR DESCRIPTION
I add the info shared on Slack, but I'm wondering why [this document](https://github.com/forwards/conferences/blob/master/Introduction%20to%20the%20Forwards%20Conferences%20Team.md) is not the readme file.

Also, the readme should have links to our CoC and our Guide to contributing. Does that exist in someplace?
Also would be nice to have a governance file on the repo where we explain how we function and make decisions (I think that is on the web page right?)